### PR TITLE
Add Sparkle auto-update support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,14 +33,27 @@ jobs:
   release:
     needs: test
     runs-on: macos-15
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: brew install xcodegen create-dmg
 
+      - name: Install Sparkle CLI tools
+        run: |
+          SPARKLE_VERSION="2.9.0"
+          curl -sL "https://github.com/sparkle-project/Sparkle/releases/download/$SPARKLE_VERSION/Sparkle-for-Swift-Package-Manager.zip" -o sparkle-spm.zip
+          unzip -qo sparkle-spm.zip -d sparkle-spm
+          echo "$PWD/sparkle-spm/bin" >> "$GITHUB_PATH"
+          rm sparkle-spm.zip
+
       - name: Generate Xcode project
-        run: xcodegen generate
+        run: |
+          xcodegen generate
+          /usr/libexec/PlistBuddy -c 'Set :CFBundleShortVersionString $(MARKETING_VERSION)' Notes/Info.plist
+          /usr/libexec/PlistBuddy -c 'Set :CFBundleVersion $(CURRENT_PROJECT_VERSION)' Notes/Info.plist
 
       - name: Import signing certificate
         env:
@@ -66,6 +79,8 @@ jobs:
         run: echo -n "$NOTARIZATION_KEY" | base64 --decode -o $RUNNER_TEMP/notarization_key.p8
 
       - name: Build
+        env:
+          SPARKLE_ED_PUBLIC_KEY: ${{ secrets.SPARKLE_ED_PUBLIC_KEY }}
         run: |
           xcodebuild -project Tidbits.xcodeproj \
             -scheme Tidbits \
@@ -78,7 +93,37 @@ jobs:
             ENABLE_HARDENED_RUNTIME=YES \
             OTHER_CODE_SIGN_FLAGS=--timestamp \
             CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
+            SPARKLE_ED_PUBLIC_KEY="$SPARKLE_ED_PUBLIC_KEY" \
+            CURRENT_PROJECT_VERSION="${{ github.run_number }}" \
             build
+
+      - name: Inject Sparkle public key
+        env:
+          SPARKLE_ED_PUBLIC_KEY: ${{ secrets.SPARKLE_ED_PUBLIC_KEY }}
+        run: |
+          APP_PATH=.derivedData/Build/Products/Release/Tidbits.app
+          /usr/libexec/PlistBuddy -c "Set :SUPublicEDKey $SPARKLE_ED_PUBLIC_KEY" "$APP_PATH/Contents/Info.plist" 2>/dev/null \
+            || /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string $SPARKLE_ED_PUBLIC_KEY" "$APP_PATH/Contents/Info.plist"
+
+      - name: Codesign Sparkle framework
+        run: |
+          APP_PATH=.derivedData/Build/Products/Release/Tidbits.app
+          FW="$APP_PATH/Contents/Frameworks/Sparkle.framework"
+
+          # Sign sub-components if they exist (may vary by Sparkle version)
+          for component in \
+            "$FW/Versions/B/XPCServices/Downloader.xpc" \
+            "$FW/Versions/B/XPCServices/Installer.xpc" \
+            "$FW/Versions/B/Autoupdate" \
+            "$FW/Versions/B/Updater.app"; do
+            if [ -e "$component" ]; then
+              codesign --force --sign "Developer ID Application" --timestamp -o runtime "$component"
+            fi
+          done
+
+          # These must succeed — no || true
+          codesign --force --sign "Developer ID Application" --timestamp -o runtime "$FW"
+          codesign --force --sign "Developer ID Application" --timestamp -o runtime "$APP_PATH"
 
       - name: Notarize app
         env:
@@ -132,6 +177,29 @@ jobs:
 
           xcrun stapler staple Tidbits.dmg
 
+      - name: Sign DMG for Sparkle
+        env:
+          SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+        run: |
+          KEY_FILE=$RUNNER_TEMP/sparkle_key
+          echo -n "$SPARKLE_ED_PRIVATE_KEY" > "$KEY_FILE"
+
+          SIGN_OUTPUT=$(sign_update Tidbits.dmg --ed-key-file "$KEY_FILE")
+          echo "Sparkle signature: $SIGN_OUTPUT"
+
+          ED_SIGNATURE=$(echo "$SIGN_OUTPUT" | grep -o 'sparkle:edSignature="[^"]*"' | cut -d'"' -f2)
+          FILE_LENGTH=$(echo "$SIGN_OUTPUT" | grep -o 'length="[^"]*"' | cut -d'"' -f2)
+
+          if [ -z "$ED_SIGNATURE" ] || [ -z "$FILE_LENGTH" ]; then
+            echo "ERROR: Failed to parse sign_update output: $SIGN_OUTPUT"
+            exit 1
+          fi
+
+          echo "SPARKLE_ED_SIGNATURE=$ED_SIGNATURE" >> "$GITHUB_ENV"
+          echo "SPARKLE_FILE_LENGTH=$FILE_LENGTH" >> "$GITHUB_ENV"
+
+          rm -f "$KEY_FILE"
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -141,9 +209,30 @@ jobs:
             --title "Tidbits ${{ github.ref_name }}" \
             --generate-notes
 
+      - name: Update appcast
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+          BUILD="${{ github.run_number }}"
+          DMG_URL="https://github.com/${{ github.repository }}/releases/download/$TAG/Tidbits.dmg"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+
+          bash scripts/update-appcast.sh "$VERSION" "$BUILD" "$SPARKLE_ED_SIGNATURE" "$SPARKLE_FILE_LENGTH" "$DMG_URL"
+
+          git add appcast.xml
+          git commit -m "Update appcast for $TAG"
+          git push origin main
+
       - name: Cleanup
         if: always()
         run: |
           security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
-          rm -f $RUNNER_TEMP/certificate.p12 $RUNNER_TEMP/notarization_key.p8
+          rm -f $RUNNER_TEMP/certificate.p12 $RUNNER_TEMP/notarization_key.p8 $RUNNER_TEMP/sparkle_key
           rm -f .derivedData/Build/Products/Release/Tidbits.zip
+          rm -rf sparkle-spm

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ CLAUDE.local.md
 # Release artifacts
 .release/
 
+# Sparkle test keys and local server files
+.sparkle/
+
 # Claude Code
 .claude/
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,8 @@ kill:
 # Generate Xcode project from project.yml
 generate:
 	@xcodegen generate
+	@/usr/libexec/PlistBuddy -c 'Set :CFBundleShortVersionString $$(MARKETING_VERSION)' Notes/Info.plist
+	@/usr/libexec/PlistBuddy -c 'Set :CFBundleVersion $$(CURRENT_PROJECT_VERSION)' Notes/Info.plist
 
 # Build the app (Release). Uses Signing.xcconfig when present, otherwise ad-hoc.
 build: generate
@@ -107,3 +109,4 @@ dmg:
 
 # Full release pipeline: build → notarize app → staple app → create/sign/notarize DMG (maintainer only)
 release: notarize staple dmg
+

--- a/Notes/Info.plist
+++ b/Notes/Info.plist
@@ -4,15 +4,55 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Tidbits</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>Tidbits</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.productivity</string>
+	<key>LSUIElement</key>
+	<true/>
+	<key>NSAccessibilityUsageDescription</key>
+	<string>Tidbits needs Accessibility permission to capture selected text with a global keyboard shortcut.</string>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSKeyEquivalent</key>
+			<dict>
+				<key>default</key>
+				<string>T</string>
+			</dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Add to Tidbits</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>addToTidbitsService</string>
+			<key>NSSendTypes</key>
+			<array>
+				<string>public.rtf</string>
+				<string>public.html</string>
+				<string>public.utf8-plain-text</string>
+				<string>public.plain-text</string>
+			</array>
+		</dict>
+	</array>
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/tidbits-tools/tidbits/main/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string>$(SPARKLE_ED_PUBLIC_KEY)</string>
 </dict>
 </plist>

--- a/Notes/Sources/NotesApp.swift
+++ b/Notes/Sources/NotesApp.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import AppKit
 import NotesCore
 import ApplicationServices
+import Sparkle
 
 @MainActor
 final class AppState: ObservableObject {
@@ -44,6 +45,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     var appState: AppState?
     private let servicesProvider = ServicesProvider()
     private let hotkeyManager = HotkeyManager()
+    private let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
     private var mainWindow: NSWindow?
     private var permissionWindow: NSWindow?
     private var onboardingWindow: NSWindow?
@@ -182,6 +184,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
     private func showContextMenu() {
         guard let button = AppDelegate.retainedStatusItem?.button else { return }
         let menu = NSMenu()
+        let checkForUpdates = NSMenuItem(title: "Check for Updates…", action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)), keyEquivalent: "")
+        checkForUpdates.target = updaterController
+        menu.addItem(checkForUpdates)
+        menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Quit Tidbits", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q"))
         menu.popUp(positioning: nil, at: NSPoint(x: 0, y: button.bounds.maxY + 5), in: button)
     }

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <channel>
+    <title>Tidbits Updates</title>
+  </channel>
+</rss>

--- a/project.yml
+++ b/project.yml
@@ -11,6 +11,9 @@ settings:
 packages:
   NotesCore:
     path: NotesCore
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    exactVersion: "2.9.0"
 
 targets:
   Tidbits:
@@ -37,6 +40,8 @@ targets:
         LSApplicationCategoryType: public.app-category.productivity
         LSUIElement: true
         NSAccessibilityUsageDescription: Tidbits needs Accessibility permission to capture selected text with a global keyboard shortcut.
+        SUFeedURL: https://raw.githubusercontent.com/tidbits-tools/tidbits/main/appcast.xml
+        SUPublicEDKey: $(SPARKLE_ED_PUBLIC_KEY)
         NSServices:
           - NSMenuItem:
               default: Add to Tidbits
@@ -51,5 +56,7 @@ targets:
     dependencies:
       - package: NotesCore
         product: NotesCore
+      - package: Sparkle
+        product: Sparkle
 
 

--- a/scripts/update-appcast.sh
+++ b/scripts/update-appcast.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# Updates appcast.xml with a new release item.
+# Called by the release workflow after building and signing.
+#
+# Usage: ./scripts/update-appcast.sh <version> <build> <signature> <length> <dmg-url>
+# Example: ./scripts/update-appcast.sh 1.1.0 2 "abc123..." 1747529 "https://github.com/.../Tidbits.dmg"
+
+VERSION="$1"
+BUILD="$2"
+ED_SIGNATURE="$3"
+FILE_LENGTH="$4"
+DMG_URL="$5"
+APPCAST="appcast.xml"
+PUBLISH_DATE=$(date -u +"%a, %d %b %Y %H:%M:%S +0000")
+
+NEW_ITEM="    <item>
+      <title>Version $VERSION</title>
+      <pubDate>$PUBLISH_DATE</pubDate>
+      <sparkle:version>$BUILD</sparkle:version>
+      <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+      <enclosure
+        url=\"$DMG_URL\"
+        sparkle:edSignature=\"$ED_SIGNATURE\"
+        length=\"$FILE_LENGTH\"
+        type=\"application/octet-stream\"
+      />
+    </item>"
+
+# Insert new item after <channel><title>...</title>
+# Uses awk to find the closing </title> tag and insert after it
+awk -v item="$NEW_ITEM" '
+  /<\/title>/ && !inserted {
+    print
+    print item
+    inserted = 1
+    next
+  }
+  { print }
+' "$APPCAST" > "${APPCAST}.tmp"
+
+mv "${APPCAST}.tmp" "$APPCAST"
+echo "Updated appcast.xml with version $VERSION (build $BUILD)"


### PR DESCRIPTION
## Summary

- Integrates Sparkle 2.9.0 via SPM for automatic updates
- Adds "Check for Updates…" to the menu bar context menu
- Extends the release workflow to EdDSA-sign DMGs and update `appcast.xml` in the repo
- Appcast hosted at `raw.githubusercontent.com` — no external infrastructure needed

## Before first release

Add these GitHub Actions secrets:
- `SPARKLE_ED_PUBLIC_KEY` — EdDSA public key string
- `SPARKLE_ED_PRIVATE_KEY` — exported private key contents

Generate with:
```bash
# After resolving Sparkle SPM package:
.build/artifacts/sparkle/Sparkle/bin/generate_keys
.build/artifacts/sparkle/Sparkle/bin/generate_keys -x /tmp/sparkle_private_key
```

## Test plan

- [x] Verified Sparkle local update flow end-to-end (`make sparkle-test`)
- [x] All 222 unit tests pass
- [ ] Cut a test release and verify appcast.xml is updated on main
- [ ] Verify "Check for Updates…" finds the new version from an older install

🤖 Generated with [Claude Code](https://claude.com/claude-code)