### PR TITLE
Use Apple's official action for certificate import

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,25 +56,10 @@ jobs:
           /usr/libexec/PlistBuddy -c 'Set :CFBundleVersion $(CURRENT_PROJECT_VERSION)' Notes/Info.plist
 
       - name: Import signing certificate
-        env:
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-        run: |
-          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
-          CERT_PATH=$RUNNER_TEMP/certificate.p12
-
-          echo -n "$MACOS_CERTIFICATE" | base64 --decode -o $CERT_PATH
-
-          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security import $CERT_PATH -P "$MACOS_CERTIFICATE_PWD" -A -T /usr/bin/codesign -T /usr/bin/security -f pkcs12 -k $KEYCHAIN_PATH
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
-          security list-keychains -d user -s $KEYCHAIN_PATH $(security list-keychains -d user | tr -d '"')
-
-          # Verify identity was imported
-          security find-identity -v -p codesigning $KEYCHAIN_PATH
+        uses: Apple-Actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.MACOS_CERTIFICATE }}
+          p12-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
 
       - name: Decode notarization key
         env:
@@ -235,7 +220,6 @@ jobs:
       - name: Cleanup
         if: always()
         run: |
-          security delete-keychain $RUNNER_TEMP/app-signing.keychain-db 2>/dev/null || true
-          rm -f $RUNNER_TEMP/certificate.p12 $RUNNER_TEMP/notarization_key.p8 $RUNNER_TEMP/sparkle_key
+          rm -f $RUNNER_TEMP/notarization_key.p8 $RUNNER_TEMP/sparkle_key
           rm -f .derivedData/Build/Products/Release/Tidbits.zip
           rm -rf sparkle-spm


### PR DESCRIPTION
## Summary
- Replace hand-rolled `security` commands with `Apple-Actions/import-codesign-certs@v3`
- Fixes silent private key import failure that was causing `set-key-partition-list: SecItemCopyMatching: The specified item could not be found in the keychain`
- Remove manual keychain cleanup (action manages its own keychain)

## Test plan
- [ ] Release workflow passes the "Import signing certificate" step
- [ ] Build step successfully signs with Developer ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)