### PR TITLE
Add error logging to sign_update step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,11 @@ jobs:
           KEY_FILE=$RUNNER_TEMP/sparkle_key
           echo -n "$SPARKLE_ED_PRIVATE_KEY" > "$KEY_FILE"
 
-          SIGN_OUTPUT=$(sign_update Tidbits.dmg --ed-key-file "$KEY_FILE")
+          SIGN_OUTPUT=$(sign_update Tidbits.dmg --ed-key-file "$KEY_FILE" 2>&1) || {
+            echo "sign_update failed with exit code $?"
+            echo "Output: $SIGN_OUTPUT"
+            exit 1
+          }
           echo "Sparkle signature: $SIGN_OUTPUT"
 
           ED_SIGNATURE=$(echo "$SIGN_OUTPUT" | grep -o 'sparkle:edSignature="[^"]*"' | cut -d'"' -f2)


### PR DESCRIPTION
## Summary

- Captures stderr from `sign_update` so we can see the actual error when it fails
- Currently it exits with code 1 and shows nothing

## Test plan

- [ ] Merge, tag a new release, check the log output on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)