### PR TITLE
Fix sign_update: strip trailing whitespace from secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,9 +169,8 @@ jobs:
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
         run: |
-          echo "Key length: ${#SPARKLE_ED_PRIVATE_KEY} chars"
-          echo "sign_update path: $(which sign_update)"
-          SIGN_OUTPUT=$(printf '%s' "$SPARKLE_ED_PRIVATE_KEY" | sign_update Tidbits.dmg --ed-key-file - 2>&1) || {
+          SPARKLE_KEY=$(printf '%s' "$SPARKLE_ED_PRIVATE_KEY" | tr -d '[:space:]')
+          SIGN_OUTPUT=$(printf '%s' "$SPARKLE_KEY" | sign_update Tidbits.dmg --ed-key-file - 2>&1) || {
             echo "sign_update failed with exit code $?"
             echo "Output: $SIGN_OUTPUT"
             exit 1


### PR DESCRIPTION
## Summary

- GitHub secrets adds a trailing newline to stored values (45 chars instead of 44)
- `sign_update` can't decode the key because the newline makes it invalid base64
- Strips all whitespace before piping to `sign_update`

## Test plan

- [ ] Merge, retag v1.0.0, verify sign_update succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)