### PR TITLE
Add direct DMG download link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Browsers, terminals, AI apps, editors, mail, notes — anything with selectable 
 
 ## Download
 
-Get the app at [tidbits.tools](https://tidbits.tools). Requires macOS 14.0+.
+[**Download Tidbits**](https://github.com/tidbits-tools/tidbits/releases/latest/download/Tidbits.dmg) — or visit [tidbits.tools](https://tidbits.tools). Requires macOS 14.0+.
 
 ## Build from source
 


### PR DESCRIPTION
## Summary
- Adds a direct GitHub Releases DMG download link to the README Download section
- Keeps the existing tidbits.tools link as a secondary option

## Test plan
- [ ] Verify the download link resolves to the latest DMG

🤖 Generated with [Claude Code](https://claude.com/claude-code)