### PR TITLE
Fix copy path buttons to return raw file paths

### DIFF
--- a/Notes/Sources/ContentView.swift
+++ b/Notes/Sources/ContentView.swift
@@ -481,7 +481,9 @@ struct PageDetailView: View {
 
     private func copyPagePrompt() {
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(ClaudePrompt.page(title: page.title), forType: .string)
+        let slug = appState.store?.slug(forPageID: page.id)
+        let path = slug.map { ClaudePrompt.page(slug: $0) } ?? ClaudePrompt.allNotes()
+        NSPasteboard.general.setString(path, forType: .string)
     }
 
     private func debouncedSave(pageID: String, snippetID: String, text: String) {

--- a/NotesCore/Sources/NotesCore/ClaudePrompt.swift
+++ b/NotesCore/Sources/NotesCore/ClaudePrompt.swift
@@ -4,13 +4,10 @@ public enum ClaudePrompt {
     public static let notesDirectory = "~/Library/Application Support/TidbitsLocal"
 
     public static func allNotes() -> String {
-        "Read my notes index at \(notesDirectory)/index.json and page files in \(notesDirectory)/pages/ — these are my saved tidbits organized into pages."
+        notesDirectory
     }
 
-    public static func page(title: String, slug: String? = nil) -> String {
-        if let slug {
-            return "Read the page \"\(title)\" from \(notesDirectory)/pages/\(slug).json"
-        }
-        return "Read the page \"\(title)\" — find its slug in \(notesDirectory)/index.json, then read \(notesDirectory)/pages/{slug}.json"
+    public static func page(slug: String) -> String {
+        "\(notesDirectory)/pages/\(slug).json"
     }
 }

--- a/NotesCore/Sources/NotesCore/NotesStore.swift
+++ b/NotesCore/Sources/NotesCore/NotesStore.swift
@@ -60,6 +60,10 @@ public actor NotesStore {
         pages[id]
     }
 
+    public func slug(forPageID pageID: String) -> String? {
+        index[pageID]?.slug
+    }
+
     // MARK: - Write
 
     @discardableResult

--- a/NotesCore/Tests/NotesCoreTests/ClaudePromptTests.swift
+++ b/NotesCore/Tests/NotesCoreTests/ClaudePromptTests.swift
@@ -15,85 +15,28 @@ final class ClaudePromptTests: XCTestCase {
 
     // MARK: - allNotes
 
-    func testAllNotes_ContainsIndexPath() {
-        let prompt = ClaudePrompt.allNotes()
-        XCTAssertTrue(prompt.contains("index.json"))
-    }
-
-    func testAllNotes_ContainsPagesDirectory() {
-        let prompt = ClaudePrompt.allNotes()
-        XCTAssertTrue(prompt.contains("pages/"))
-    }
-
-    func testAllNotes_ContainsReadInstruction() {
-        let prompt = ClaudePrompt.allNotes()
-        XCTAssertTrue(prompt.hasPrefix("Read my notes"))
-    }
-
-    func testAllNotes_MentionsPages() {
-        let prompt = ClaudePrompt.allNotes()
-        XCTAssertTrue(prompt.contains("pages"))
+    func testAllNotes_ReturnsDirectoryPath() {
+        XCTAssertEqual(ClaudePrompt.allNotes(), "~/Library/Application Support/TidbitsLocal")
     }
 
     func testAllNotes_IsStable() {
         XCTAssertEqual(ClaudePrompt.allNotes(), ClaudePrompt.allNotes())
     }
 
-    func testAllNotes_ExactPaths() {
-        let prompt = ClaudePrompt.allNotes()
-        XCTAssertTrue(prompt.contains("~/Library/Application Support/TidbitsLocal/index.json"))
-        XCTAssertTrue(prompt.contains("~/Library/Application Support/TidbitsLocal/pages/"))
-    }
-
     // MARK: - page
 
-    func testPage_ContainsTitle() {
-        let prompt = ClaudePrompt.page(title: "Daily Journal")
-        XCTAssertTrue(prompt.contains("\"Daily Journal\""))
+    func testPage_ReturnsFilePath() {
+        let path = ClaudePrompt.page(slug: "daily-journal")
+        XCTAssertEqual(path, "~/Library/Application Support/TidbitsLocal/pages/daily-journal.json")
     }
 
-    func testPage_WithSlug_ContainsDirectPath() {
-        let prompt = ClaudePrompt.page(title: "Daily Journal", slug: "daily-journal")
-        XCTAssertTrue(prompt.contains("daily-journal.json"))
-        XCTAssertFalse(prompt.contains("index.json"), "Should not need index fallback when slug is provided")
+    func testPage_CollisionSlug() {
+        let path = ClaudePrompt.page(slug: "duplicate-2")
+        XCTAssertTrue(path.contains("duplicate-2.json"))
     }
 
-    func testPage_WithoutSlug_FallsBackToIndex() {
-        let prompt = ClaudePrompt.page(title: "Test")
-        XCTAssertTrue(prompt.contains("index.json"))
-        XCTAssertTrue(prompt.contains("{slug}.json"))
-    }
-
-    func testPage_ContainsReadInstruction() {
-        let prompt = ClaudePrompt.page(title: "Test", slug: "test")
-        XCTAssertTrue(prompt.hasPrefix("Read the page"))
-    }
-
-    func testPage_QuotesTitleProperly() {
-        let prompt = ClaudePrompt.page(title: "My \"Special\" Page", slug: "my-special-page")
-        XCTAssertTrue(prompt.contains("My \"Special\" Page"))
-    }
-
-    func testPage_HandlesEmptyTitle() {
-        let prompt = ClaudePrompt.page(title: "", slug: "untitled")
-        XCTAssertTrue(prompt.contains("untitled.json"))
-    }
-
-    func testPage_HandlesLongTitle() {
-        let longTitle = String(repeating: "a", count: 1000)
-        let prompt = ClaudePrompt.page(title: longTitle, slug: "aaa")
-        XCTAssertTrue(prompt.contains(longTitle))
-    }
-
-    func testPage_ExactPath_WithSlug() {
-        let prompt = ClaudePrompt.page(title: "HN thinking", slug: "hn-thinking")
-        XCTAssertTrue(prompt.contains("~/Library/Application Support/TidbitsLocal/pages/hn-thinking.json"))
-    }
-
-    func testPage_CollisionSlug_UsesProvidedSlug() {
-        // If the store resolved a collision suffix, the prompt should use it
-        let prompt = ClaudePrompt.page(title: "Duplicate", slug: "duplicate-2")
-        XCTAssertTrue(prompt.contains("duplicate-2.json"))
-        XCTAssertFalse(prompt.contains("index.json"))
+    func testPage_DoesNotContainIndex() {
+        let path = ClaudePrompt.page(slug: "test")
+        XCTAssertFalse(path.contains("index.json"))
     }
 }


### PR DESCRIPTION
## Summary
- Both "Copy path" buttons (sidebar and document page) were copying AI prompt sentences instead of actual file paths
- Sidebar now copies `~/Library/Application Support/TidbitsLocal/` (the data directory)
- Document button now copies `~/Library/Application Support/TidbitsLocal/pages/{slug}.json` (the specific page file, using the correct collision-resolved slug from the index)
- Added `NotesStore.slug(forPageID:)` public method to expose slug lookup
- Simplified `ClaudePrompt` API to return plain paths

## Test plan
- [x] All 212 tests pass
- [ ] Build app, click sidebar "Copy path" → verify clipboard contains just the directory path
- [ ] Open a document, click "Copy Path" → verify clipboard contains the specific `.json` file path
- [ ] Create two pages with the same title, verify the second page's copy path includes the `-2` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)