### PR TITLE
Derive MARKETING_VERSION from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
             OTHER_CODE_SIGN_FLAGS=--timestamp \
             CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO \
             SPARKLE_ED_PUBLIC_KEY="$SPARKLE_ED_PUBLIC_KEY" \
+            MARKETING_VERSION="${GITHUB_REF_NAME#v}" \
             CURRENT_PROJECT_VERSION="${{ github.run_number }}" \
             build
 


### PR DESCRIPTION
## Summary

- Extract version from the tag name (v1.1.0 → 1.1.0) and pass as `MARKETING_VERSION` to xcodebuild
- No more manual `project.yml` edits before tagging
- Release process is now just: `git tag v1.1.0 && git push origin v1.1.0`

## Test plan

- [ ] Tag v1.0.2, verify the built app shows "1.0.2" (not "1.0.0" from project.yml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)